### PR TITLE
[FIX] 작성한 게시글이 없을 경우, 해시태그가 없는 게시물이 있는 경우 처리

### DIFF
--- a/src/components/post_overview/PostContainer.tsx
+++ b/src/components/post_overview/PostContainer.tsx
@@ -34,9 +34,15 @@ const PostContainer: React.FC<PostContainerProps> = ({ hashTag }) => {
 
     const handlePostList = async () => {
         try {
-            const response = await postList(hashTag);
-            setPosts(response.data.content);
-            return response.data.content;
+            if (hashTag === "None") {
+                const response = await postList("");
+                setPosts(response.data.content);
+                return response.data.content;
+            } else {
+                const response = await postList(hashTag);
+                setPosts(response.data.content);
+                return response.data.content;
+            }
         } catch (error) {
             console.error("게시글 목록 조회 실패: ", hashTag, error);
         }

--- a/src/pages/Main.module.css
+++ b/src/pages/Main.module.css
@@ -1,7 +1,17 @@
 .container {
     width: 100%;
     height: 100%;
+    min-height: 100vh;
     background-color: #efefef;
     padding: 75px 0;
     box-sizing: border-box;
+}
+
+.empty {
+    margin-top: 50px;
+    padding-left: 50px;
+}
+
+.emptyText {
+    font-weight: bold;
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -5,6 +5,7 @@ import PostContainer from "../components/post_overview/PostContainer";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { hashtagList } from "../apis/postApi";
+import CreateButton from "../components/post_overview/CreateButton";
 
 const MainPage: React.FC = () => {
     const navigate = useNavigate();
@@ -36,9 +37,19 @@ const MainPage: React.FC = () => {
                 {/* 학습 트래커 컨테이너 */}
                 <Tracker />
                 {/* 게시글 목록 */}
-                {sortType.map((tag) => (
-                    <PostContainer key={tag} hashTag={tag} />
-                ))}
+                {sortType && sortType.length > 0 ? (
+                    <>
+                    {sortType.map((tag) => (
+                        <PostContainer key={tag} hashTag={tag} />
+                    ))}
+                    <PostContainer hashTag={"None"} />
+                    </>
+                ) : (
+                    <div className={styles.empty}>
+                        <div>지금 기록을 시작해보세요!</div>
+                        <CreateButton />
+                    </div>
+                )}
             </div>
         </>
     );


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
작성한 게시글이 없을 경우, 해시태그가 없는 게시물이 있는 경우에 대한 처리 작업

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 사용자가 작성한 게시글이 한 개도 없는 경우 게시글 생성 버튼이 메인 화면에 렌더링 되도록 변경
- 해시태그가 없는 게시물의 경우 None이란 필드에서 게시글을 확인할 수 있도록 구현

## 🧪 테스트 체크리스트
- [x] 게시글이 하나도 없는 사용자로 로그인 후 메인 화면 렌더링 확인
- [x] 해시태그가 없는 게시물 생성 후 None 필드 확인 

## ✅ 체크리스트
- [ ] 로컬에서 테스트를 완료했나요?
- [ ] Assignees를 등록했나요?
- [ ] Label을 지정했나요?