### PR TITLE
[FIX] 기록이 아무것도 없을 때도 none 필드 보이도록 추가

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -38,18 +38,16 @@ const MainPage: React.FC = () => {
                 <Tracker />
                 {/* 게시글 목록 */}
                 {sortType && sortType.length > 0 ? (
-                    <>
-                    {sortType.map((tag) => (
+                    sortType.map((tag) => (
                         <PostContainer key={tag} hashTag={tag} />
-                    ))}
-                    <PostContainer hashTag={"None"} />
-                    </>
+                    ))
                 ) : (
                     <div className={styles.empty}>
                         <div>지금 기록을 시작해보세요!</div>
                         <CreateButton />
                     </div>
                 )}
+                <PostContainer hashTag={"None"} />
             </div>
         </>
     );


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
기록이 아무것도 없을 때도 none 필드 보이도록 추가

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 기록이 아무것도 없는 상태에서 해시태그 없는 게시물 생성 시 메인에서 확인 불가한 오류 수정

## 🧪 테스트 체크리스트
- [ ] 새로운 사용자로 해시태그 없는 게시물 생성, 메인화면 렌더링 확인

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?